### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,8 @@ on:
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   e2e-tests:
@@ -31,11 +33,68 @@ jobs:
       - name: Run E2E Tests
         working-directory: tests
         run: ./run_tests.sh
+        continue-on-error: true
 
       - name: Capture Logs on Failure
         if: failure()
         working-directory: tests
         run: docker compose -f docker-compose.test.yml logs > service_logs.txt
+
+      - name: Parse Test Results
+        if: always()
+        id: test-results
+        uses: dorny/test-reporter@v1
+        with:
+          name: E2E Test Results
+          path: tests/reports/test_results.xml
+          reporter: java-junit
+          fail-on-error: false
+
+      - name: Generate Test Report Summary
+        if: always()
+        run: |
+          if [ -f tests/reports/test_results.xml ]; then
+            # Parse XML to extract test counts
+            PASSED=$(grep -o 'tests="[^"]*"' tests/reports/test_results.xml | head -1 | cut -d'"' -f2)
+            FAILED=$(grep -o 'failures="[^"]*"' tests/reports/test_results.xml | head -1 | cut -d'"' -f2)
+            SKIPPED=$(grep -o 'skipped="[^"]*"' tests/reports/test_results.xml | head -1 | cut -d'"' -f2)
+            
+            # Set defaults if not found
+            PASSED=${PASSED:-0}
+            FAILED=${FAILED:-0}
+            SKIPPED=${SKIPPED:-0}
+            
+            TOTAL=$((PASSED + FAILED))
+            
+            if [ "$TOTAL" -gt 0 ]; then
+              PASS_PERCENT=$((PASSED * 100 / TOTAL))
+              FAIL_PERCENT=$((FAILED * 100 / TOTAL))
+            else
+              PASS_PERCENT=0
+              FAIL_PERCENT=0
+            fi
+            
+            echo "## 📊 Test Report Summary" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Metric | Count | Percentage |" >> $GITHUB_STEP_SUMMARY
+            echo "|--------|-------|------------|" >> $GITHUB_STEP_SUMMARY
+            echo "| ✅ Passed | $PASSED | $PASS_PERCENT% |" >> $GITHUB_STEP_SUMMARY
+            echo "| ❌ Failed | $FAILED | $FAIL_PERCENT% |" >> $GITHUB_STEP_SUMMARY
+            echo "| ⏭️  Skipped | $SKIPPED | - |" >> $GITHUB_STEP_SUMMARY
+            echo "| 📈 Total | $TOTAL | 100% |" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Status" >> $GITHUB_STEP_SUMMARY
+            
+            if [ "$FAILED" -eq 0 ] && [ "$TOTAL" -gt 0 ]; then
+              echo "✅ All tests passed!" >> $GITHUB_STEP_SUMMARY
+            elif [ "$TOTAL" -eq 0 ]; then
+              echo "⚠️ No tests found" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "❌ Some tests failed" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "⚠️ No test results file found" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Upload Test Report
         if: always()
@@ -50,3 +109,7 @@ jobs:
         with:
           name: service-logs
           path: tests/service_logs.txt
+
+      - name: Fail if tests failed
+        if: failure() || steps.test-results.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     name: E2E Integration Tests


### PR DESCRIPTION
Potential fix for [https://github.com/sagniKdas53/yt-diff/security/code-scanning/17](https://github.com/sagniKdas53/yt-diff/security/code-scanning/17)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged.  
Best fix: define workflow-level permissions right after `on:` (or before `jobs:`) with only what this workflow needs. For this file, `contents: read` is sufficient for checkout and artifact upload does not require extra token write scopes.

Edit `.github/workflows/run-tests.yml`:
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
- Place it at top level (same indentation as `on:` and `jobs:`), before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
