### PR TITLE
Potential fix for code scanning alert no. 23: Incomplete URL substring sanitization

### DIFF
--- a/src/handlers/pipeline/dedup.ts
+++ b/src/handlers/pipeline/dedup.ts
@@ -57,12 +57,17 @@ export interface DeduplicateResult {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+function isHostOrSubdomain(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
 export function canonicalizeVideoUrl(urlStr: string): string {
   try {
     const url = new URL(urlStr);
 
     if (
-      url.hostname.includes("youtube.com") || url.hostname.includes("youtu.be")
+      isHostOrSubdomain(url.hostname, "youtube.com") ||
+      isHostOrSubdomain(url.hostname, "youtu.be")
     ) {
       url.hostname = "www.youtube.com";
       if (url.pathname.startsWith("/shorts/")) {
@@ -78,28 +83,29 @@ export function canonicalizeVideoUrl(urlStr: string): string {
       const v = url.searchParams.get("v");
       url.search = "";
       if (v) url.searchParams.set("v", v);
-    } else if (url.hostname.includes("iwara.tv")) {
+    } else if (isHostOrSubdomain(url.hostname, "iwara.tv")) {
       const parts = url.pathname.split("/").filter(Boolean);
       if (parts.length >= 2 && parts[0] === "video") {
         url.pathname = `/video/${parts[1]}`;
       }
       url.search = "";
-    } else if (url.hostname.includes("spankbang.com")) {
+    } else if (isHostOrSubdomain(url.hostname, "spankbang.com")) {
       const parts = url.pathname.split("/").filter(Boolean);
       if (parts.length >= 2 && parts[1] === "video") {
         url.pathname = `/${parts[0]}/video`;
       }
       url.search = "";
-    } else if (url.hostname.includes("xhamster.com")) {
+    } else if (isHostOrSubdomain(url.hostname, "xhamster.com")) {
       url.search = "";
-    } else if (url.hostname.includes("pornhub.com")) {
+    } else if (isHostOrSubdomain(url.hostname, "pornhub.com")) {
       const viewkey = url.searchParams.get("viewkey");
       url.search = "";
       if (viewkey) url.searchParams.set("viewkey", viewkey);
     }
 
     if (
-      url.hostname.includes("x.com") || url.hostname.includes("twitter.com")
+      isHostOrSubdomain(url.hostname, "x.com") ||
+      isHostOrSubdomain(url.hostname, "twitter.com")
     ) {
       url.searchParams.set("s", "20");
     }


### PR DESCRIPTION
Potential fix for [https://github.com/sagniKdas53/yt-diff/security/code-scanning/23](https://github.com/sagniKdas53/yt-diff/security/code-scanning/23)

The correct fix is to stop using raw substring checks on hostnames and instead perform **domain-aware matching**:
- exact match for the apex domain, or
- suffix match with a dot boundary for subdomains (`.twitter.com`, `.x.com`, etc.).

In `src/handlers/pipeline/dedup.ts`, update the host checks in `canonicalizeVideoUrl` (the `includes(...)` conditions) to use a helper that validates host boundaries. This preserves functionality (supporting intended domains and subdomains) while preventing accidental matches like `eviltwitter.com`.

Best implementation in this snippet:
1. Add a small helper function (e.g., `isHostOrSubdomain(hostname, domain)`).
2. Replace `url.hostname.includes("twitter.com")` and related checks with this helper.
3. (Recommended for consistency and to avoid similar bypasses) apply the same helper to other domain checks in this shown function (`youtube.com`, `youtu.be`, `iwara.tv`, `spankbang.com`, `xhamster.com`, `pornhub.com`).

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
